### PR TITLE
CompareTo method fully implemented

### DIFF
--- a/Source/Tests/TexasHoldem.Logic.Tests/Helpers/BestHandTests.cs
+++ b/Source/Tests/TexasHoldem.Logic.Tests/Helpers/BestHandTests.cs
@@ -397,9 +397,9 @@
         public void CompareToShouldWorkCorrectly(
             ExpectedCompareResult expectedCompareResult,
             HandRankType firstHandRankType,
-            ICollection<CardType> firstCardTypes,
+            IList<CardType> firstCardTypes,
             HandRankType secondHandRankType,
-            ICollection<CardType> secondCardTypes)
+            IList<CardType> secondCardTypes)
         {
             var firstBestHand = new BestHand(firstHandRankType, firstCardTypes.Shuffle().ToList());
             var secondBestHand = new BestHand(secondHandRankType, secondCardTypes.Shuffle().ToList());

--- a/Source/Tests/TexasHoldem.Logic.Tests/Helpers/HandEvaluatorTests.cs
+++ b/Source/Tests/TexasHoldem.Logic.Tests/Helpers/HandEvaluatorTests.cs
@@ -235,8 +235,8 @@
                         HandRankType.Straight,
                         new[]
                         {
-                            CardType.Ace, CardType.Two, CardType.Three,
-                            CardType.Four, CardType.Five
+                            CardType.Five, CardType.Four, CardType.Three,
+                            CardType.Two, CardType.LowAce
                         }
                     },
                 new object[]
@@ -423,8 +423,8 @@
                         HandRankType.StraightFlush,
                         new[]
                             {
-                                CardType.Ace, CardType.Two, CardType.Three,
-                                CardType.Four, CardType.Five
+                                CardType.Five, CardType.Four, CardType.Three,
+                                CardType.Two, CardType.LowAce
                             }
                     },
                 new object[]
@@ -443,8 +443,8 @@
                         HandRankType.StraightFlush,
                         new[]
                             {
-                                CardType.Ace, CardType.Two, CardType.Three,
-                                CardType.Four, CardType.Five
+                                CardType.Five, CardType.Four, CardType.Three,
+                                CardType.Two, CardType.LowAce
                             }
                     },
             };

--- a/Source/TexasHoldem.Logic/Cards/CardType.cs
+++ b/Source/TexasHoldem.Logic/Cards/CardType.cs
@@ -15,5 +15,6 @@
         Queen = 12,
         King = 13,
         Ace = 14,
+        LowAce = 1
     }
 }

--- a/Source/TexasHoldem.Logic/Helpers/BestHand.cs
+++ b/Source/TexasHoldem.Logic/Helpers/BestHand.cs
@@ -2,13 +2,12 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
 
     using TexasHoldem.Logic.Cards;
 
     public class BestHand : IComparable<BestHand>
     {
-        internal BestHand(HandRankType rankType, ICollection<CardType> cards)
+        internal BestHand(HandRankType rankType, IList<CardType> cards)
         {
             if (cards.Count != 5)
             {
@@ -20,7 +19,7 @@
         }
 
         // When comparing or ranking cards, the suit doesn't matter
-        public ICollection<CardType> Cards { get; }
+        public IList<CardType> Cards { get; }
 
         public HandRankType RankType { get; }
 
@@ -36,132 +35,25 @@
                 return -1;
             }
 
-            // TODO: What if same rank type?
-            switch (this.RankType)
+            for (var i = 0; i < this.Cards.Count; i++)
             {
-                case HandRankType.HighCard:
-                    return CompareTwoHandsWithHighCard(this.Cards, other.Cards);
-                case HandRankType.Pair:
-                    return CompareTwoHandsWithPair(this.Cards, other.Cards);
-                case HandRankType.TwoPairs:
-                    return CompareTwoHandsWithTwoPairs(this.Cards, other.Cards);
-                case HandRankType.ThreeOfAKind:
-                    return CompareTwoHandsWithThreeOfAKind(this.Cards, other.Cards);
-                case HandRankType.Straight:
-                    return CompareTwoHandsWithStraight(this.Cards, other.Cards);
-                case HandRankType.Flush:
-                    return CompareTwoHandsWithHighCard(this.Cards, other.Cards);
-                case HandRankType.FullHouse:
-                    return CompareTwoHandsWithFullHouse(this.Cards, other.Cards);
-                case HandRankType.FourOfAKind:
-                    return CompareTwoHandsWithFourOfAKind(this.Cards, other.Cards);
-                case HandRankType.StraightFlush:
-                    return CompareTwoHandsWithStraightFlush(this.Cards, other.Cards);
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }
-        }
+                // Not sure if much sense of this.
+                if (this.Cards[i] == other.Cards[i])
+                {
+                    continue;
+                }
 
-        private static int CompareTwoHandsWithHighCard(
-            ICollection<CardType> firstHand,
-            ICollection<CardType> secondHand)
-        {
-            var firstSorted = firstHand.OrderBy(x => x).ToList();
-            var secondSorted = secondHand.OrderBy(x => x).ToList();
-            var cardsToCompare = Math.Min(firstHand.Count, secondHand.Count);
-            for (var i = 0; i < cardsToCompare; i++)
-            {
-                if (firstSorted[i] > secondSorted[i])
+                if (this.Cards[i] > other.Cards[i])
                 {
                     return 1;
                 }
 
-                if (firstSorted[i] < secondSorted[i])
+                if (this.Cards[i] < other.Cards[i])
                 {
                     return -1;
                 }
             }
 
-            return 0;
-        }
-
-        private static int CompareTwoHandsWithPair(
-            ICollection<CardType> firstHand,
-            ICollection<CardType> secondHand)
-        {
-            var firstPairType = firstHand.GroupBy(x => x).First(x => x.Count() >= 2);
-            var secondPairType = secondHand.GroupBy(x => x).First(x => x.Count() >= 2);
-
-            if (firstPairType.Key > secondPairType.Key)
-            {
-                return 1;
-            }
-
-            if (firstPairType.Key < secondPairType.Key)
-            {
-                return -1;
-            }
-
-            // Equal pair => compare high card
-            return CompareTwoHandsWithHighCard(firstHand, secondHand);
-        }
-
-        private static int CompareTwoHandsWithTwoPairs(
-            ICollection<CardType> firstHand,
-            ICollection<CardType> secondHand)
-        {
-            var firstPairType = firstHand.GroupBy(x => x).Where(x => x.Count() == 2).OrderByDescending(x => x.Key).ToList();
-            var secondPairType = secondHand.GroupBy(x => x).Where(x => x.Count() == 2).OrderByDescending(x => x.Key).ToList();
-
-            for (int i = 0; i < firstPairType.Count; i++)
-            {
-                if (firstPairType[i].Key > secondPairType[i].Key)
-                {
-                    return 1;
-                }
-
-                if (secondPairType[i].Key > firstPairType[i].Key)
-                {
-                    return -1;
-                }
-            }
-
-            // Equal pairs => compare high card
-            return CompareTwoHandsWithHighCard(firstHand, secondHand);
-        }
-
-        private static int CompareTwoHandsWithThreeOfAKind(
-            ICollection<CardType> firstHand,
-            ICollection<CardType> secondHand)
-        {
-            return 0;
-        }
-
-        private static int CompareTwoHandsWithStraight(
-            ICollection<CardType> firstHand,
-            ICollection<CardType> secondHand)
-        {
-            return 0;
-        }
-
-        private static int CompareTwoHandsWithFullHouse(
-            ICollection<CardType> firstHand,
-            ICollection<CardType> secondHand)
-        {
-            return 0;
-        }
-
-        private static int CompareTwoHandsWithFourOfAKind(
-            ICollection<CardType> firstHand,
-            ICollection<CardType> secondHand)
-        {
-            return 0;
-        }
-
-        private static int CompareTwoHandsWithStraightFlush(
-            ICollection<CardType> firstHand,
-            ICollection<CardType> secondHand)
-        {
             return 0;
         }
     }

--- a/Source/TexasHoldem.Logic/Helpers/HandEvaluator.cs
+++ b/Source/TexasHoldem.Logic/Helpers/HandEvaluator.cs
@@ -70,8 +70,8 @@
                     cards.Where(x => x.Type != bestThreeOfAKindType)
                         .OrderBy(x => x.Type)
                         .Select(x => x.Type)
-                        .Skip(cards.Count - 2)
-                        .Take(ComparableCards - 3).ToList();
+                        .Skip(cards.Count - ComparableCards)
+                        .ToList();
                 bestCards.AddRange(Enumerable.Repeat(bestThreeOfAKindType, 3));
                 bestCards.Reverse();
 
@@ -99,9 +99,9 @@
                 var bestCards =
                     cards.Where(x => x.Type != pairTypes[0])
                         .OrderBy(x => x.Type)
+                        .Skip(cards.Count - ComparableCards)
                         .Select(x => x.Type)
-                        .Skip(cards.Count - 3)
-                        .Take(ComparableCards - 2).ToList();
+                        .ToList();
                 bestCards.Add(pairTypes[0]);
                 bestCards.Add(pairTypes[0]);
                 bestCards.Reverse();
@@ -132,9 +132,17 @@
 
         private IList<CardType> GetStraightFlushCards(ICollection<Card> cards)
         {
-            var flush = cards.GroupBy(x => x.Suit).First(x => x.Count() >= ComparableCards).ToList();
+            var flushes = cards.GroupBy(x => x.Suit).Where(x => x.Count() >= ComparableCards).Select(x => x.ToList());
+            foreach (var group in flushes)
+            {
+                var straightCards = this.GetStraightCards(group);
+                if (straightCards != null)
+                {
+                    return straightCards;
+                }
+            }
 
-            return flush == null ? null : this.GetStraightCards(flush);
+            return null;
         }
 
         private IList<CardType> GetStraightCards(ICollection<Card> cards)
@@ -142,7 +150,7 @@
             var types = cards.GroupBy(x => x.Type).Select(x => (int)x.Key).OrderByDescending(x => x).ToList();
             if (types[0] == (int)CardType.Ace)
             {
-                types.Add((int)CardType.Two - 1);
+                types.Add((int)CardType.LowAce);
             }
 
             var cardsCount = types.Count;
@@ -152,7 +160,7 @@
             straightCards.Add((CardType)lastType);
             for (var i = 1; i < cardsCount; i++)
             {
-                if (types[i] - 1 == lastType)
+                if (types[i] + 1 == lastType)
                 {
                     currentSequence++;
                     straightCards.Add((CardType)types[i]);


### PR DESCRIPTION
hands now come with highest ranked cards first followed by highest kickers - hopefully..
hand tests reworked to new conditions,
best hand tests now wont work with shuffled cards because no sorting in CompareTo method - tests have to be reworked if the method stays
Hopefully not many bugs created - further - have to do some homeworks :) 
GL guys - hope helped 