### PR TITLE
Fix bug in HandEvaluator

### DIFF
--- a/Source/Tests/TexasHoldem.Logic.Tests/Helpers/HandEvaluatorTests.cs
+++ b/Source/Tests/TexasHoldem.Logic.Tests/Helpers/HandEvaluatorTests.cs
@@ -538,6 +538,25 @@
                                 CardType.Ace, CardType.Two
                             }
                     },
+                new object[]
+                    {
+                        new[]
+                            {
+                                new Card(CardSuit.Spade, CardType.Ace),
+                                new Card(CardSuit.Spade, CardType.Ace),
+                                new Card(CardSuit.Spade, CardType.Ace),
+                                new Card(CardSuit.Spade, CardType.Ace),
+                                new Card(CardSuit.Spade, CardType.Ten),
+                                new Card(CardSuit.Spade, CardType.Seven),
+                                new Card(CardSuit.Spade, CardType.Three)
+                            },
+                        HandRankType.FourOfAKind,
+                        new[]
+                            {
+                                CardType.Ace, CardType.Ace, CardType.Ace,
+                                CardType.Ace, CardType.Ten
+                            }
+                    },
             };
 
         private static readonly object[] StraightFlushCases =

--- a/Source/Tests/TexasHoldem.Logic.Tests/TexasHoldem.Logic.Tests.csproj
+++ b/Source/Tests/TexasHoldem.Logic.Tests/TexasHoldem.Logic.Tests.csproj
@@ -77,6 +77,9 @@
     <Analyzer Include="..\..\packages\StyleCop.Analyzers.1.0.0-beta015\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
     <Analyzer Include="..\..\packages\StyleCop.Analyzers.1.0.0-beta015\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\packages\StyleCop.Analyzers.1.0.0-beta015\build\StyleCop.Analyzers.targets" Condition="Exists('..\..\packages\StyleCop.Analyzers.1.0.0-beta015\build\StyleCop.Analyzers.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/Source/TexasHoldem.Logic/Helpers/HandEvaluator.cs
+++ b/Source/TexasHoldem.Logic/Helpers/HandEvaluator.cs
@@ -9,6 +9,7 @@
     public class HandEvaluator : IHandEvaluator
     {
         private const int ComparableCards = 5;
+        private bool hasFlash = false;
 
         public BestHand GetBestHand(IEnumerable<Card> cards)
         {
@@ -20,29 +21,16 @@
                 cardTypeCounts[(int)card.Type]++;
             }
 
-            // Flushes
-            if (cardSuitCounts.Any(x => x >= ComparableCards))
+            this.hasFlash = cardSuitCounts.Any(x => x >= ComparableCards);
+
+            // Straight flush
+            if (this.hasFlash)
             {
                 // Straight flush
                 var straightFlushCards = this.GetStraightFlushCards(cardSuitCounts, cards);
                 if (straightFlushCards.Count > 0)
                 {
                     return new BestHand(HandRankType.StraightFlush, straightFlushCards);
-                }
-
-                // Flush
-                for (var i = 0; i < cardSuitCounts.Length; i++)
-                {
-                    if (cardSuitCounts[i] >= ComparableCards)
-                    {
-                        var flushCards =
-                            cards.Where(x => x.Suit == (CardSuit)i)
-                                .Select(x => x.Type)
-                                .OrderByDescending(x => x)
-                                .Take(ComparableCards)
-                                .ToList();
-                        return new BestHand(HandRankType.Flush, flushCards);
-                    }
                 }
             }
 
@@ -90,6 +78,24 @@
                 }
 
                 return new BestHand(HandRankType.FullHouse, bestCards);
+            }
+
+            // Flush
+            if (this.hasFlash)
+            {
+                for (var i = 0; i < cardSuitCounts.Length; i++)
+                {
+                    if (cardSuitCounts[i] >= ComparableCards)
+                    {
+                        var flushCards =
+                            cards.Where(x => x.Suit == (CardSuit)i)
+                                .Select(x => x.Type)
+                                .OrderByDescending(x => x)
+                                .Take(ComparableCards)
+                                .ToList();
+                        return new BestHand(HandRankType.Flush, flushCards);
+                    }
+                }
             }
 
             // Straight


### PR DESCRIPTION
When we have four of a kind and flush hand types as possible combinations, the best hand type chosen should be four of a kind, but instead flush was returned. Fixed that and also added a unit test case in four of a kind for this particular case.