### PR TITLE
Revert "Fix bug in HandEvaluator"

### DIFF
--- a/Source/Tests/TexasHoldem.Logic.Tests/Helpers/HandEvaluatorTests.cs
+++ b/Source/Tests/TexasHoldem.Logic.Tests/Helpers/HandEvaluatorTests.cs
@@ -538,25 +538,6 @@
                                 CardType.Ace, CardType.Two
                             }
                     },
-                new object[]
-                    {
-                        new[]
-                            {
-                                new Card(CardSuit.Spade, CardType.Ace),
-                                new Card(CardSuit.Spade, CardType.Ace),
-                                new Card(CardSuit.Spade, CardType.Ace),
-                                new Card(CardSuit.Spade, CardType.Ace),
-                                new Card(CardSuit.Spade, CardType.Ten),
-                                new Card(CardSuit.Spade, CardType.Seven),
-                                new Card(CardSuit.Spade, CardType.Three)
-                            },
-                        HandRankType.FourOfAKind,
-                        new[]
-                            {
-                                CardType.Ace, CardType.Ace, CardType.Ace,
-                                CardType.Ace, CardType.Ten
-                            }
-                    },
             };
 
         private static readonly object[] StraightFlushCases =

--- a/Source/Tests/TexasHoldem.Logic.Tests/TexasHoldem.Logic.Tests.csproj
+++ b/Source/Tests/TexasHoldem.Logic.Tests/TexasHoldem.Logic.Tests.csproj
@@ -78,9 +78,6 @@
     <Analyzer Include="..\..\packages\StyleCop.Analyzers.1.0.0-beta016\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
     <Analyzer Include="..\..\packages\StyleCop.Analyzers.1.0.0-beta016\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
   </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Source/TexasHoldem.Logic/Helpers/HandEvaluator.cs
+++ b/Source/TexasHoldem.Logic/Helpers/HandEvaluator.cs
@@ -9,7 +9,6 @@
     public class HandEvaluator : IHandEvaluator
     {
         private const int ComparableCards = 5;
-        private bool hasFlash = false;
 
         public BestHand GetBestHand(IEnumerable<Card> cards)
         {
@@ -21,16 +20,29 @@
                 cardTypeCounts[(int)card.Type]++;
             }
 
-            this.hasFlash = cardSuitCounts.Any(x => x >= ComparableCards);
-
-            // Straight flush
-            if (this.hasFlash)
+            // Flushes
+            if (cardSuitCounts.Any(x => x >= ComparableCards))
             {
                 // Straight flush
                 var straightFlushCards = this.GetStraightFlushCards(cardSuitCounts, cards);
                 if (straightFlushCards.Count > 0)
                 {
                     return new BestHand(HandRankType.StraightFlush, straightFlushCards);
+                }
+
+                // Flush
+                for (var i = 0; i < cardSuitCounts.Length; i++)
+                {
+                    if (cardSuitCounts[i] >= ComparableCards)
+                    {
+                        var flushCards =
+                            cards.Where(x => x.Suit == (CardSuit)i)
+                                .Select(x => x.Type)
+                                .OrderByDescending(x => x)
+                                .Take(ComparableCards)
+                                .ToList();
+                        return new BestHand(HandRankType.Flush, flushCards);
+                    }
                 }
             }
 
@@ -78,24 +90,6 @@
                 }
 
                 return new BestHand(HandRankType.FullHouse, bestCards);
-            }
-
-            // Flush
-            if (this.hasFlash)
-            {
-                for (var i = 0; i < cardSuitCounts.Length; i++)
-                {
-                    if (cardSuitCounts[i] >= ComparableCards)
-                    {
-                        var flushCards =
-                            cards.Where(x => x.Suit == (CardSuit)i)
-                                .Select(x => x.Type)
-                                .OrderByDescending(x => x)
-                                .Take(ComparableCards)
-                                .ToList();
-                        return new BestHand(HandRankType.Flush, flushCards);
-                    }
-                }
             }
 
             // Straight


### PR DESCRIPTION
It turns out that such cases are not possible, because we cannot have both flush and full house or four of a kind at the same time with standart texas hold-em rules (7 cards total). Sorry for that. Previous version was better because it skipped four of a kind and full house if flush was discovered first, which is more likely to be found.