### PR TITLE
Add showdown

### DIFF
--- a/Source/TexasHoldem.Logic/GameMechanics/TwoPlayersHandLogic.cs
+++ b/Source/TexasHoldem.Logic/GameMechanics/TwoPlayersHandLogic.cs
@@ -21,6 +21,8 @@
 
         private readonly TwoPlayersBettingLogic bettingLogic;
 
+        private Dictionary<string, ICollection<Card>> showdownCards;
+
         public TwoPlayersHandLogic(IList<InternalPlayer> players, int handNumber, int smallBlind)
         {
             this.handNumber = handNumber;
@@ -69,10 +71,18 @@
 
             this.DetermineWinnerAndAddPot(this.bettingLogic.Pot);
 
+            // showdown
             foreach (var player in this.players)
             {
-                // TODO: Showdown?
-                player.EndHand(new EndHandContext());
+                if (player.PlayerMoney.InHand)
+                {
+                    this.showdownCards.Add(player.Name, player.Cards);
+                }
+            }
+
+            foreach (var player in this.players)
+            {
+                player.EndHand(new EndHandContext(this.showdownCards));
             }
         }
 

--- a/Source/TexasHoldem.Logic/Players/EndHandContext.cs
+++ b/Source/TexasHoldem.Logic/Players/EndHandContext.cs
@@ -1,6 +1,15 @@
 ﻿namespace TexasHoldem.Logic.Players
 {
+    using System.Collections.Generic;
+    using TexasHoldem.Logic.Cards;
+
     public class EndHandContext
     {
+        public EndHandContext(Dictionary<string, ICollection<Card>> showdownCards)
+        {
+            this.ShowdownCards = showdownCards;
+        }
+
+        public Dictionary<string, ICollection<Card>> ShowdownCards { get; private set; }
     }
 }


### PR DESCRIPTION
Add showdown functionality to TwoPlayersHandLogic. The list of player`s showdown cards is passed as property ShowdownCards of the EndHandContext object to IPlayer.EndHand() method.
Issue #15