### PR TITLE
Implement showdown

### DIFF
--- a/Source/TexasHoldem.Logic/GameMechanics/TwoPlayersHandLogic.cs
+++ b/Source/TexasHoldem.Logic/GameMechanics/TwoPlayersHandLogic.cs
@@ -21,6 +21,8 @@
 
         private readonly TwoPlayersBettingLogic bettingLogic;
 
+        private Dictionary<string, ICollection<Card>> showdownCards;
+
         public TwoPlayersHandLogic(IList<InternalPlayer> players, int handNumber, int smallBlind)
         {
             this.handNumber = handNumber;
@@ -69,10 +71,18 @@
 
             this.DetermineWinnerAndAddPot(this.bettingLogic.Pot);
 
+            // showdown
             foreach (var player in this.players)
             {
-                // TODO: Showdown?
-                player.EndHand(new EndHandContext());
+                if (player.PlayerMoney.InHand)
+                {
+                    this.showdownCards.Add(player.Name, player.Cards);
+                }
+            }
+
+            foreach (var player in this.players)
+            {
+                player.EndHand(new EndHandContext(this.showdownCards));
             }
         }
 

--- a/Source/TexasHoldem.Logic/GameMechanics/TwoPlayersHandLogic.cs
+++ b/Source/TexasHoldem.Logic/GameMechanics/TwoPlayersHandLogic.cs
@@ -71,15 +71,6 @@
 
             this.DetermineWinnerAndAddPot(this.bettingLogic.Pot);
 
-            // showdown
-            foreach (var player in this.players)
-            {
-                if (player.PlayerMoney.InHand)
-                {
-                    this.showdownCards.Add(player.Name, player.Cards);
-                }
-            }
-
             foreach (var player in this.players)
             {
                 player.EndHand(new EndHandContext(this.showdownCards));
@@ -95,6 +86,15 @@
             }
             else
             {
+                // showdown
+                foreach (var player in this.players)
+                {
+                    if (player.PlayerMoney.InHand)
+                    {
+                        this.showdownCards.Add(player.Name, player.Cards);
+                    }
+                }
+
                 var betterHand = Helpers.CompareCards(
                     this.players[0].Cards.Concat(this.communityCards),
                     this.players[1].Cards.Concat(this.communityCards));

--- a/Source/TexasHoldem.Logic/Players/EndHandContext.cs
+++ b/Source/TexasHoldem.Logic/Players/EndHandContext.cs
@@ -1,6 +1,15 @@
 ﻿namespace TexasHoldem.Logic.Players
 {
+    using System.Collections.Generic;
+    using TexasHoldem.Logic.Cards;
+
     public class EndHandContext
     {
+        public EndHandContext(Dictionary<string, ICollection<Card>> showdownCards)
+        {
+            this.ShowdownCards = showdownCards;
+        }
+
+        public Dictionary<string, ICollection<Card>> ShowdownCards { get; private set; }
     }
 }


### PR DESCRIPTION
Add showdown functionality to TwoPlayersHandLogic. 
After all bets are off during the river only if more than one players have not folded their cards are shown. The lists of players`s showdown cards are passed as property ShowdownCards of the EndHandContext object to IPlayer.EndHand() method. 
This could be useful if a bot is looking for bluffs.
See Issue #15.