### PR TITLE
Small fix to showdown in TwoPlayersHandLogic

### DIFF
--- a/Source/TexasHoldem.Logic/GameMechanics/TwoPlayersHandLogic.cs
+++ b/Source/TexasHoldem.Logic/GameMechanics/TwoPlayersHandLogic.cs
@@ -31,7 +31,8 @@
             this.deck = new Deck();
             this.communityCards = new List<Card>(5);
             this.bettingLogic = new TwoPlayersBettingLogic(this.players, smallBlind);
-        }
+            this.showdownCards = new Dictionary<string, ICollection<Card>>();
+    }
 
         public void Play()
         {


### PR DESCRIPTION
Initialize field showdownCards in the constructor. Otherwise this resulted in NullReferenceException under certain circumstances.