### PR TITLE
More consistent maming for game simulator classes

### DIFF
--- a/Source/Tests/TexasHoldem.Logic.Tests/TexasHoldem.Logic.Tests.csproj
+++ b/Source/Tests/TexasHoldem.Logic.Tests/TexasHoldem.Logic.Tests.csproj
@@ -78,6 +78,9 @@
     <Analyzer Include="..\..\packages\StyleCop.Analyzers.1.0.0-beta016\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
     <Analyzer Include="..\..\packages\StyleCop.Analyzers.1.0.0-beta016\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Source/Tests/TexasHoldem.Tests.GameSimulations/GameSimulators/AlwaysCallPlayersGameSimulator.cs
+++ b/Source/Tests/TexasHoldem.Tests.GameSimulations/GameSimulators/AlwaysCallPlayersGameSimulator.cs
@@ -6,7 +6,7 @@
     /// <summary>
     /// For performance profiling
     /// </summary>
-    public class AlwaysCallPlayersGameSimulation : BaseGameSimulator
+    public class AlwaysCallPlayersGameSimulator : BaseGameSimulator
     {
         private readonly IPlayer firstPlayer = new AlwaysCallDummyPlayer();
         private readonly IPlayer secondPlayer = new AlwaysCallDummyPlayer();

--- a/Source/Tests/TexasHoldem.Tests.GameSimulations/GameSimulators/SmartVsAlwaysCallPlayerSimulator.cs
+++ b/Source/Tests/TexasHoldem.Tests.GameSimulations/GameSimulators/SmartVsAlwaysCallPlayerSimulator.cs
@@ -4,7 +4,7 @@
     using TexasHoldem.AI.SmartPlayer;
     using TexasHoldem.Logic.Players;
 
-    internal class SmartVsAlwaysCallPlayerSimulation : BaseGameSimulator
+    internal class SmartVsAlwaysCallPlayerSimulator : BaseGameSimulator
     {
         private readonly IPlayer firstPlayer = new SmartPlayer();
 

--- a/Source/Tests/TexasHoldem.Tests.GameSimulations/Program.cs
+++ b/Source/Tests/TexasHoldem.Tests.GameSimulations/Program.cs
@@ -8,10 +8,10 @@
     {
         public static void Main()
         {
-            SimulateGames(new SmartVsAlwaysCallPlayerSimulation());
+            SimulateGames(new SmartVsAlwaysCallPlayerSimulator());
             SimulateGames(new SmartVsDummyPlayerSimulator());
             SimulateGames(new SmartVsSmartPlayerSimulator());
-            SimulateGames(new AlwaysCallPlayersGameSimulation());
+            SimulateGames(new AlwaysCallPlayersGameSimulator());
         }
 
         private static void SimulateGames(IGameSimulator gameSimulator)

--- a/Source/Tests/TexasHoldem.Tests.GameSimulations/TexasHoldem.Tests.GameSimulations.csproj
+++ b/Source/Tests/TexasHoldem.Tests.GameSimulations/TexasHoldem.Tests.GameSimulations.csproj
@@ -61,11 +61,11 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="GameSimulators\AlwaysCallPlayersGameSimulation.cs" />
+    <Compile Include="GameSimulators\AlwaysCallPlayersGameSimulator.cs" />
     <Compile Include="GameSimulators\BaseGameSimulator.cs" />
     <Compile Include="GameSimulators\GameSimulationResult.cs" />
     <Compile Include="GameSimulators\IGameSimulator.cs" />
-    <Compile Include="GameSimulators\SmartVsAlwaysCallPlayerSimulation.cs" />
+    <Compile Include="GameSimulators\SmartVsAlwaysCallPlayerSimulator.cs" />
     <Compile Include="GameSimulators\SmartVsDummyPlayerSimulator.cs" />
     <Compile Include="GameSimulators\SmartVsSmartPlayerSimulator.cs" />
     <Compile Include="Program.cs" />

--- a/Source/TexasHoldem.Logic/Helpers/HandEvaluator.cs
+++ b/Source/TexasHoldem.Logic/Helpers/HandEvaluator.cs
@@ -10,6 +10,11 @@
     {
         private const int ComparableCards = 5;
 
+        /// <summary>
+        /// Finds the best possible hand given a player's cards and all revealed comunity cards.
+        /// </summary>
+        /// <param name="cards">A player's cards + all revealed comunity cards (at lesat 5 in total)</param>
+        /// <returns>Returns an object of type BestHand</returns>
         public BestHand GetBestHand(IEnumerable<Card> cards)
         {
             var cardSuitCounts = new int[(int)CardSuit.Spade + 1];


### PR DESCRIPTION
Changed all BaseGameSimulator children class names ending with "Simulation" to the more commonly used in the project GameSimulator