### PR TITLE
Proposal on raising with invalid amount

### DIFF
--- a/Source/TexasHoldem.Logic/Players/PlayerAction.cs
+++ b/Source/TexasHoldem.Logic/Players/PlayerAction.cs
@@ -45,7 +45,7 @@
         {
             if (withAmount <= 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(withAmount), "Raise amount should be at least 1");
+                return CheckOrCall();
             }
 
             return new PlayerAction(withAmount);


### PR DESCRIPTION
When raising with invalid amount (e.g. <= 0) return CheckOrCall instead of throwing error