### PR TITLE
Add AllIn information functionality.

### DIFF
--- a/Source/TexasHoldem.Logic/GameMechanics/InternalPlayerMoney.cs
+++ b/Source/TexasHoldem.Logic/GameMechanics/InternalPlayerMoney.cs
@@ -63,10 +63,15 @@
                 }
                 else
                 {
-                    // All-in
-                    action.Money = this.Money;
-                    this.PlaceMoney(action.Money);
+                    // Temporal solution. If player tries to raise with more money than he has (all in).
+                    return this.DoPlayerAction(PlayerAction.AllIn(action.Money), maxMoneyPerPlayer);
                 }
+            }
+            else if (action.Type == PlayerActionType.AllIn)
+            {
+                // All-in - important to be accessible as information through "PreviousRoundActions".
+                action.Money = this.Money;
+                this.PlaceMoney(action.Money);
             }
             else if (action.Type == PlayerActionType.CheckCall)
             {

--- a/Source/TexasHoldem.Logic/Players/PlayerAction.cs
+++ b/Source/TexasHoldem.Logic/Players/PlayerAction.cs
@@ -12,9 +12,9 @@
             this.Type = type;
         }
 
-        private PlayerAction(int money)
+        private PlayerAction(int money, bool isAllIn = false)
         {
-            this.Type = PlayerActionType.Raise;
+            this.Type = isAllIn ? PlayerActionType.AllIn : PlayerActionType.Raise;
             this.Money = money;
         }
 
@@ -38,7 +38,6 @@
         /// <param name="withAmount">
         /// The amount to raise with.
         /// If amount is less than the minimum amount for raising then the game will take this minimum amount from the players money.
-        /// If amount is more or equal to the players money the player will be in all-in state
         /// </param>
         /// <returns>A new player action object containing information about the player action and the raise amount</returns>
         public static PlayerAction Raise(int withAmount)
@@ -49,6 +48,24 @@
             }
 
             return new PlayerAction(withAmount);
+        }
+
+        /// <summary>
+        /// Creates a new object containing information about the player action.
+        /// </summary>
+        /// <param name="moneyLeft">
+        /// The amount of money player has left to all-in with.
+        /// If amount is less than the minimum amount for raising then the game will take this minimum amount from the players money.
+        /// </param>
+        /// <returns>A new player action object containing information about the player action and the raise amount</returns>
+        public static PlayerAction AllIn(int moneyLeft)
+        {
+            if (moneyLeft <= 0)
+            {
+                return CheckOrCall();
+            }
+
+            return new PlayerAction(moneyLeft, true);
         }
 
         public override string ToString()

--- a/Source/TexasHoldem.Logic/Players/PlayerActionType.cs
+++ b/Source/TexasHoldem.Logic/Players/PlayerActionType.cs
@@ -5,5 +5,6 @@
         Fold = 0,
         CheckCall = 1,
         Raise = 2,
+        AllIn = 3
     }
 }


### PR DESCRIPTION
* Add PlayerActionType.AllIn, 

* InternalPlayerMoney logic modified to return proper result when all-in. 

* PlayerAction modified to give access to AllIn();

* Named parameter moneyLeft to be consistent with context.MoneyLeft.

* Used optiona bool to reuse constructor.

* DoPlayerAction will recall itself when called with more money than player has with ActionType.AllIn - temporal solution.

I know it is late but just realized there is no real information if opponent is all-in.

Only magic such as (my.MoneyLeft + CurrentPot + MoneyToCall == 2000).

* Working out the Unit Test now :(